### PR TITLE
Add stored token for Authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [Interface](#interface)
 - [JSON Structure](#json-structure)
 - [Global Settings](#global-settings)
+  - [Authentication](#authentication)
 - [Tiles](#tiles)
   - [Payload](#payload)
   - [Buttons](#buttons)
@@ -52,7 +53,8 @@ Currently due to limitations in how clay config works, I have opted to directly 
   "keep_alive": false,
   "base_url": "",
   "headers": {},
-  "tiles": []
+  "tiles": [],
+  "authentication": {...}
 }
 ```
 
@@ -82,6 +84,44 @@ Example:
   ]
 }
 ```
+
+## Authentication
+
+The authentication key is an optional key in the global section of the config that allows you to configure a login endpoint for storing a token to interact with the rest of your endpoints. At minimum, `method`, `url` and `data` are required in order for authentication to be used in the application.
+
+
+```json
+ "authentication": {
+    "method": "",
+    "url": "",
+    "data": {},
+    "headers": {},
+    "variable": "",
+    "prefix": ""
+  }
+```
+
+|Key          |Expected type|Description|
+|-------------|-------------|-----------|
+|method       |`string`     |XHR Method to use for authentication endpoint. |
+|url          |`string`     |Partial or full url, see `base_url` in [global settings](#global-settings)|
+|data         |`Object`     |Data object to send to the endpoint. (Such as credentials) |
+|headers      |`Object`     |Optional headers to send alongside data, overidden by `headers` in [global settings](#global-settings)|
+|prefix       |`string`     |The prefix before the token in the header, defaults to `"Bearer "`|
+|variable     |`string`     |A variable to extract from the return data, use dot notation to traverse a nested object. Defaults to `"access_token"`. |
+
+Example: 
+```json
+ "authentication": {
+    "method": "POST",
+    "url": "login",
+    "data": {"username": "user", "password": "password123"},
+    "headers": {"Content-Type": "application/json"},
+    "variable": "access_token",
+    "prefix": "Bearer "
+  }
+```
+
 
 # Tiles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.5.1",
+        "ieee754": "1.2.1",
+        "isarray": "1.0.0"
       }
     },
     "ieee754": {
@@ -30,8 +30,7 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "pebble-clay": {
-      "version": "github:kennedn/clay#49cd60f5ea1cf0aae92d052fdf28ff1c28f9c3f6",
-      "from": "github:kennedn/clay#TextArea"
+      "version": "github:kennedn/clay#49cd60f5ea1cf0aae92d052fdf28ff1c28f9c3f6"
     }
   }
 }

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -40,6 +40,38 @@ module.exports =
     "type": "section",
     "items": [
       {
+        "type": "heading",
+        "defaultValue": "API Login"
+      },
+      {
+        "type": "text",
+        "defaultValue": "Use this section to define a username and password that will be POSTed to the login URL to obtain a token. All values must be defined to be used."
+      },
+      {
+        "type": "input",
+        "label": "API Username",
+        "id": "api_username"
+      },
+      {
+        "type": "input",
+        "label": "API Password",
+        "id": "api_password",
+        "attributes": {
+          "type": "password"
+        }
+      },
+      {
+        "type": "input",
+        "label": "Login URL",
+        "description": "After base_url, without leading slash",
+        "id": "login_url"
+      }
+    ]
+  },
+  {
+    "type": "section",
+    "items": [
+      {
         "type": "button",
         "id": "Submit",
         "defaultValue": "Submit",

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -40,38 +40,6 @@ module.exports =
     "type": "section",
     "items": [
       {
-        "type": "heading",
-        "defaultValue": "API Login"
-      },
-      {
-        "type": "text",
-        "defaultValue": "Use this section to define a username and password that will be POSTed to the login URL to obtain a token. All values must be defined to be used."
-      },
-      {
-        "type": "input",
-        "label": "API Username",
-        "id": "api_username"
-      },
-      {
-        "type": "input",
-        "label": "API Password",
-        "id": "api_password",
-        "attributes": {
-          "type": "password"
-        }
-      },
-      {
-        "type": "input",
-        "label": "Login URL",
-        "description": "After base_url, without leading slash",
-        "id": "login_url"
-      }
-    ]
-  },
-  {
-    "type": "section",
-    "items": [
-      {
         "type": "button",
         "id": "Submit",
         "defaultValue": "Submit",

--- a/src/pkjs/custom-clay.js
+++ b/src/pkjs/custom-clay.js
@@ -16,10 +16,10 @@ clayConfig.on(clayConfig.EVENTS.AFTER_BUILD, function() {
   });
   $(textarea).trigger('input');
 
-  var pebblekit_header = clayConfig.getItemById('pebblekit_header')
-  var pebblekit_message = clayConfig.getItemById('pebblekit_message')
-  var json_header = clayConfig.getItemById('json_header')
-  var json_string = clayConfig.getItemById('json_string')
+  var pebblekit_header = clayConfig.getItemById('pebblekit_header');
+  var pebblekit_message = clayConfig.getItemById('pebblekit_message');
+  var json_header = clayConfig.getItemById('json_header');
+  var json_string = clayConfig.getItemById('json_string');
 
   pebblekit_header.on('click', function() {
     if (pebblekit_message.$element.get("$display") == 'none') {


### PR DESCRIPTION
Thanks for making this Pebble app! I saw this as an opportunity to interact with the REST API for [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x), but it requires obtaining and using a Bearer token for authentication rather than using static Basic authentication which I have added in this PR.

Summary of Changes:
* Added `loginIfNecessary()` function before each type of XHR request that checks for the existence of required `authentication` values from the config before calling a user-defined authentication endpoint and setting a `savedToken` which will be unset if a 401 is received as a response.
* Modified `xhrRequest()` to return the JSON data to its callback function so loginIfNecessary can access the returned token.
* Each XHR request uses the `savedToken` for the Authentication header if it is set.
* Moved `Pebble.getActiveWatchInfo()` to the `Pebble.addEventListener('ready', ...)` event listener, which was not being initialized properly in the global section (on iOS).
* Documented new "authentication" options in the JSON config:
    * method
    * url 
    * data
    * headers
    * variable
    * prefix